### PR TITLE
changed 'platform.old' to 'old/platform'

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -98,8 +98,9 @@ else
 fi
 
 echo -n "Activating new platform on $USB..."
-rm -rf usb/platform.old
-if ! ( mv usb/platform usb/platform.old && mv usb/platform.new usb/platform ) ; then
+rm -rf usb/old
+mkdir usb/old
+if ! ( mv usb/platform usb/old && mv usb/platform.new usb/platform ) ; then
         echo " failed"
         exit -1
 else


### PR DESCRIPTION
In case anyone actually needs to revert to their old platform, the path 'platform.old' will not be bootable.  Placing the 'platform' directory under the root 'old' will however enable someone to boot their old platform by editing GRUB's 'kernel' and 'module' lines accordingly.

\- Dimitri
