### PR TITLE
Print warning and exit if we detect more than one removable device

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -15,6 +15,11 @@ echo -n "Checking current boot device..."
 if [[ -z $1 ]] ; then
         usb=$(rmformat | grep Logical | awk '{print $4}' | sed 's/rdsk/dsk/;s/p0$/p1/')
         echo -n " detected $usb"
+        usb_count=(${usb})
+        if [ ${#usb_count[@]} -gt 1 ]; then
+                  echo " Warning: more than one removable device detected."
+                  exit -1
+        fi
 else   
         usb="$1"
         echo -n " using $usb"


### PR DESCRIPTION
If you have more than one removable device (for example USB and DVD/CD reader) the auto detection should fail with an warning and quit the script.
