### PR TITLE
rmformat detects CD-ROM as a removable media, use disklist -r instead

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -13,11 +13,12 @@ cd "$tmp" || exit -1
 
 echo -n "Checking current boot device..."
 if [[ -z $1 ]] ; then
-        usb=$(rmformat | grep Logical | awk '{print $4}' | sed 's/rdsk/dsk/;s/p0$/p1/')
-        echo -n " detected $usb"
-        usb_count=(${usb})
+        usb=( $(disklist -r | tr ' ' '\n' | awk '{printf "/dev/dsk/%sp1 ", $1}') )
+        echo -n " detected ${usb[@]}"
+        usb_count=(${usb[@]})
         if [ ${#usb_count[@]} -gt 1 ]; then
-                  echo " Warning: more than one removable device detected."
+                  echo
+                  echo "Warning: more than one removable device detected."
                   exit -1
         fi
 else   


### PR DESCRIPTION
rmformat is not the best choice for getting list of removable medias. One of my SmartOS node has DVD-RAM and it is reported by rmformat. 

Example output:
Looking for devices...
     1. Logical Node: /dev/rdsk/c1t0d0p0
        Physical Node: /pci@0,0/pci1014,3a3a@1d,7/storage@5/disk@0,0
        Connected Device: Kingston DT Micro         PMAP
        Device Type: Removable
        Bus: USB
        Size: 7.5 GB
        Label: <Unknown>
        Access permissions: <Unknown>
     2. Logical Node: /dev/rdsk/c3t0d0p0
        Physical Node: /pci@0,0/pci-ide@1f,2/ide@0/sd@0,0
        Connected Device: MATSHITA DVD-RAM UJ890    SAA5
        Device Type: DVD Reader/Writer
        Bus: IDE
        Size: <Unknown>
        Label: <Unknown>
        Access permissions: <Unknown>

This patch fixes this and uses disklist -r, which reports removable disks only.
