### PR TITLE
replace disklist -r with diskinfo to avoid none removable disk detected and output multi removable disks

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -73,11 +73,13 @@ fi
 
 echo -n "Checking current boot device..."
 if [[ -z $1 ]] ; then
-        removables=($(disklist -r))
+#       removables=($(disklist -r))
+        removables=($(diskinfo | awk '/^USB/ { print $2 }'))
         echo -n " detected ${removables[@]}"
         if [[ ${#removables[@]} -gt 1 ]]; then
                   echo
                   echo "Error: more than one removable device detected."
+                  diskinfo | awk 'NR == 1 || /^USB/ { print }'
                   echo "Specify correct device on the command line."
                   exit -1
         fi


### PR DESCRIPTION

patch for disklist -r with no USB disk detected, replace with disklist with diskinfo according 
https://wiki.smartos.org/display/DOC/Remotely+Upgrading+A+USB+Key+Based+Deployment

`[root@apollo /]# disklist -r

[root@apollo /]# disklist -a
  c0t50014EE20C91DF67d0 c0t50014EE20D0214F3d0 c0t50014EE20D03C4B2d0 c0t50014EE261E9ABEFd0 c0t50014EE261EA4E9Cd0 c0t50014EE2B7AD3FB0d0 c0t50014EE65A87DECCd0 c0t50014EE65A88361Bd0 c1t0d0 c2t0d0 c2t1d0 c2t2d0 c2t3d0
[root@apollo /]# disklist -n
c0t50014EE20C91DF67d0 c0t50014EE20D0214F3d0 c0t50014EE20D03C4B2d0 c0t50014EE261E9ABEFd0 c0t50014EE261EA4E9Cd0 c0t50014EE2B7AD3FB0d0 c0t50014EE65A87DECCd0 c0t50014EE65A88361Bd0 c1t0d0 c2t0d0 c2t1d0 c2t2d0 c2t3d0
[root@apollo /]# diskinfo | awk 'NR == 1 || /^USB/ { print }'
TYPE    DISK                    VID      PID              SIZE          RMV SSD
USB     c1t0d0                  HP iLO   Internal SD-CARD    7.35 GiB   no  no`

`# platform-upgrade
Downloading latest platform (platform-20160622T220759Z.tgz)... OK
Verifying checksum... OK
Extracting latest platform... OK
Marking release version... OK
**Checking current boot device... detected mount: No such file or directory
, mount failed**`

after the patch:
`# platform-upgrade
Downloading latest platform (platform-20160622T220759Z.tgz)... OK
Verifying checksum... OK
Extracting latest platform... OK
Marking release version... OK
Checking current boot device...^P detected c1t0d0^U
, mounted, OK
Updating platform on boot device...
 OK
Remounting boot device... OK
Verifying kernel checksum on boot device... OK
Verifying boot_archive checksum on boot device... OK
**Activating new platform on /dev/dsk/c1t0d0p1**... OK

Boot device upgraded. To do:

 1) Sanity check the contents of /tmp/tmp.UoainU/usb
 2) umount /dev/dsk/c1t0d0p1
 3) reboot
`
