### PR TITLE
Verify certificates for HTTPS connections

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -4,8 +4,44 @@
 # Copyright (c) 2012-2016 Jakob Borg & Contributors
 # Distributed under the MIT License
 
+# us-east.manta.joyent.com currently uses a wildcard certificate based on the
+# Thawte Primary Root CA.
+# SHA-1=91:C6:D6:EE:3E:8A:C8:63:84:E5:48:C2:99:29:5C:75:6C:81:7B:81
+# SHA-256=8D:72:2F:81:A9:C1:13:C0:79:1D:F1:36:A2:96:6D:B2:6C:95:0A:97:1D:B4:6B:41:99:F4:EA:54:B7:8B:FB:9F
+cert_file=$(mktemp)
+(
+cat <<'EOF'
+-----BEGIN CERTIFICATE-----
+MIIEIDCCAwigAwIBAgIQNE7VVyDV7exJ9C/ON9srbTANBgkqhkiG9w0BAQUFADCB
+qTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
+Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
+MDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxHzAdBgNV
+BAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwHhcNMDYxMTE3MDAwMDAwWhcNMzYw
+NzE2MjM1OTU5WjCBqTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5j
+LjEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYG
+A1UECxMvKGMpIDIwMDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNl
+IG9ubHkxHzAdBgNVBAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsoPD7gFnUnMekz52hWXMJEEUMDSxuaPFs
+W0hoSVk3/AszGcJ3f8wQLZU0HObrTQmnHNK4yZc2AreJ1CRfBsDMRJSUjQJib+ta
+3RGNKJpchJAQeg29dGYvajig4tVUROsdB58Hum/u6f1OCyn1PoSgAfGcq/gcfomk
+6KHYcWUNo1F77rzSImANuVud37r8UVsLr5iy6S7pBOhih94ryNdOwUxkHt3Ph1i6
+Sk/KaAcdHJ1KxtUvkcx8cXIcxcBn6zL9yZJclNqFwJu/U30rCfSMnZEfl2pSy94J
+NqR32HuHUETVPm4pafs5SSYeCaWAe0At6+gnhcn+Yf1+5nyXHdWdAgMBAAGjQjBA
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBR7W0XP
+r87Lev0xkhpqtvNG61dIUDANBgkqhkiG9w0BAQUFAAOCAQEAeRHAS7ORtvzw6WfU
+DW5FvlXok9LOAz/t2iWwHVfLHjp2oEzsUHboZHIMpKnxuIvW1oeEuzLlQRHAd9mz
+YJ3rG9XRbkREqaYB7FViHXe4XI5ISXycO1cRrK1zN44veFyQaEfZYGDm/Ac9IiAX
+xPcW6cTYcvnIc3zfFi8VqT79aie2oetaupgf1eNNZAqdE8hhuvU5HIe6uL17In/2
+/qxAeeWsEG89jxt5dovEN7MhGITlNgDrYyCZuen+MwS7QcjBAvlEYyCegc5C09Y/
+LHbTY5xZ3Y+m4Q6gLkH3LpVHz7z9M/P2C2F+fpErgUfCJzDupxBdN49cOSvkBPB7
+jVaMaA==
+-----END CERTIFICATE-----
+EOF
+) > $cert_file
+
 host=https://us-east.manta.joyent.com
-latest_path=$(curl -sk "$host/Joyent_Dev/public/SmartOS/latest")
+curl="curl -s --cacert $cert_file"
+latest_path=$($curl "$host/Joyent_Dev/public/SmartOS/latest")
 version="${latest_path##*/}"
 platform_file="platform-$version.tgz"
 platform_dir="platform-$version"
@@ -20,6 +56,7 @@ while getopts :f option; do
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
+            rm $cert_file
             exit -1
             ;;
     esac
@@ -29,25 +66,27 @@ shift $((OPTIND-1))
 IFS=_ read brand kernel < <(uname -v)
 if [[ $kernel == $version ]]; then
     echo "Already on latest version ($kernel)."
-    $force || exit -1
+    $force || (rm $cert_file && exit -1)
 fi
 
 tmp=$(mktemp -d)
-cd "$tmp" || exit -1
+cd "$tmp" || (rm $cert_file && exit -1)
 
 echo -n "Downloading latest platform ($platform_file)..."
-if ! curl -sk -o "$platform_file" "$platform_url" ; then
+if ! $curl -o "$platform_file" "$platform_url" ; then
         echo " failed"
+        rm $cert_file
         exit -1
 else
         echo " OK"
 fi
 
 echo -n "Verifying checksum..."
-curl -sk "$md5sums_url" \
+$curl "$md5sums_url" \
         | grep "$platform_file" \
         | awk '{print $1}' > expected.md5
 openssl md5 "$platform_file" | awk '{print $2}' > actual.md5
+rm $cert_file # Unnecessary beyond this point
 if ! cmp -s actual.md5 expected.md5 ; then
         echo " failed"
         exit -1

--- a/platform-upgrade
+++ b/platform-upgrade
@@ -9,8 +9,11 @@
 # SHA-1=91:C6:D6:EE:3E:8A:C8:63:84:E5:48:C2:99:29:5C:75:6C:81:7B:81
 # SHA-256=8D:72:2F:81:A9:C1:13:C0:79:1D:F1:36:A2:96:6D:B2:6C:95:0A:97:1D:B4:6B:41:99:F4:EA:54:B7:8B:FB:9F
 cert_file=$(mktemp)
-(
-cat <<'EOF'
+function cleanup {
+        rm "$cert_file"
+}
+trap cleanup EXIT
+cat >"$cert_file" <<EOF
 -----BEGIN CERTIFICATE-----
 MIIEIDCCAwigAwIBAgIQNE7VVyDV7exJ9C/ON9srbTANBgkqhkiG9w0BAQUFADCB
 qTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
@@ -37,11 +40,13 @@ LHbTY5xZ3Y+m4Q6gLkH3LpVHz7z9M/P2C2F+fpErgUfCJzDupxBdN49cOSvkBPB7
 jVaMaA==
 -----END CERTIFICATE-----
 EOF
-) > $cert_file
+
+function _curl {
+        curl -s --cacert "$cert_file" $@
+}
 
 host=https://us-east.manta.joyent.com
-curl="curl -s --cacert $cert_file"
-latest_path=$($curl "$host/Joyent_Dev/public/SmartOS/latest")
+latest_path=$(_curl "$host/Joyent_Dev/public/SmartOS/latest")
 version="${latest_path##*/}"
 platform_file="platform-$version.tgz"
 platform_dir="platform-$version"
@@ -56,7 +61,6 @@ while getopts :f option; do
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
-            rm $cert_file
             exit -1
             ;;
     esac
@@ -66,27 +70,25 @@ shift $((OPTIND-1))
 IFS=_ read brand kernel < <(uname -v)
 if [[ $kernel == $version ]]; then
     echo "Already on latest version ($kernel)."
-    $force || (rm $cert_file && exit -1)
+    $force || exit -1
 fi
 
 tmp=$(mktemp -d)
-cd "$tmp" || (rm $cert_file && exit -1)
+cd "$tmp" || exit -1
 
 echo -n "Downloading latest platform ($platform_file)..."
-if ! $curl -o "$platform_file" "$platform_url" ; then
+if ! _curl -o "$platform_file" "$platform_url" ; then
         echo " failed"
-        rm $cert_file
         exit -1
 else
         echo " OK"
 fi
 
 echo -n "Verifying checksum..."
-$curl "$md5sums_url" \
+_curl "$md5sums_url" \
         | grep "$platform_file" \
         | awk '{print $1}' > expected.md5
 openssl md5 "$platform_file" | awk '{print $2}' > actual.md5
-rm $cert_file # Unnecessary beyond this point
 if ! cmp -s actual.md5 expected.md5 ; then
         echo " failed"
         exit -1


### PR DESCRIPTION
Prior to this change, cURL was called with the -k flag, which disables
certificate verification.  This change stores the trusted root CA in the script
and uses it to verify certificates presented by Manta when downloading SmartOS
images.