### PR TITLE
fix find removalble devices since smartos release 20171026T003127Z no…

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -114,7 +114,10 @@ fi
 
 echo -n "Checking current boot device..."
 if [[ -z $1 ]] ; then
-        removables=($(diskinfo | awk '/^USB/ { print $2 }'))
+        removables=($(diskinfo -pH | awk '/^USB/ { print $2 }'))
+        if [[ ${#removables[@]} -eq 0 ]]; then
+                 removables=($(diskinfo -pH | awk '/^USB|^SCSI.*[0-9]+[ \s\t]+yes/ { print $2 }'))
+        fi
         echo -n " detected ${removables[@]}"
         if [[ ${#removables[@]} -gt 1 ]]; then
                   echo


### PR DESCRIPTION
Hi,


It seems that since smartos release 20171026T003127Z the diskinfo type for some usb keys is no more marked as USB
```
# diskinfo list
TYPE    DISK                    VID      PID              SIZE          RMV SSD
SCSI    c1t0d0                  JetFlash Transcend 16GB     14.52 GiB   yes no 
SATA    c2t0d0                  TOSHIBA  DT01ACA300       2794.52 GiB   no  no 
SATA    c2t1d0                  ATA      ST33000651AS     2794.52 GiB   no  no 
```

the auto detection of the usb drive is not working
the usb key is now of type SCSI and marked as RMV (removable)

added a extra detection method if search for type USB returns NO devices the search will retry
```
diskinfo -pH | awk '/^USB|^SCSI.*[0-9]+[ \s\t]+yes/ { print $2 }'
```

i also added flags -H to remove the headers and -p to output size in bytes (parsable output)

in this example case returning the removable device 
```
# diskinfo -pH | awk '/^USB|^SCSI.*[0-9]+[ \s\t]+yes/ { print $2 }'
c1t0d0
```