### PR TITLE
extract files as correct user

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -205,7 +205,7 @@ else
 fi
 
 echo -n "Updating platform on boot device..."
-if ! rsync -a "$platform_dir/" usb/platform.new/ ; then
+if ! rsync -rltD "$platform_dir/" usb/platform.new/ ; then
         echo " failed"
         exit -1
 else


### PR DESCRIPTION
Extract files as the current user, not the one that was used to build the platform image.

This can happen with custom build platforms that were created as non-root user. Since the FAT filesystem does not support different owners rsync will fail, resulting in errors like this:

```
Downloading latest platform (platform-20181227T154655Z.tgz)... OK
Verifying checksum... OK
Extracting latest platform... OK
Marking release version... OK
Checking current boot device... detected c2t0d0, mounted, OK
Updating platform on boot device...rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/." failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/amd64" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/kernel" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/kernel/amd64" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/.root.password.L3aStD" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/amd64/.boot_archive.M3aStD" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/amd64/.boot_archive.gitstatus.N3aStD" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/amd64/.boot_archive.hash.O3aStD" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/amd64/.boot_archive.manifest.P3aStD" failed: Invalid argument (22)
rsync: chown "/tmp/tmp.Jia4XC/usb/platform.new/i86pc/kernel/amd64/.unix.Q3aStD" failed: Invalid argument (22)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1189) [sender=3.1.2]
 failed
```

The fix is to just ignore the ownership information and use the current user (root).