### PR TITLE
Fix support for verifying specific platform URLs

### DIFF
--- a/platform-upgrade
+++ b/platform-upgrade
@@ -119,6 +119,7 @@ if [[ ! -n $platform_url ]]; then
         md5sums_url="$latest_path/md5sums.txt"
     fi
 else
+    header="$(expr "$platform_url" : '.*platform-release-\([0-9]\{8\}\)-.*')"
     version="$(expr "$platform_url" : '.*\([0-9]\{8\}T[0-9]\{6\}Z\).*')"
 fi
 
@@ -134,7 +135,7 @@ fi
 tmp=$(mktemp -d)
 cd "$tmp" || exit -1
 
-echo -n "Downloading latest platform ($platform_file)..."
+echo -n "Downloading $platform_file..."
 if ! _curl -o "$platform_file" "$platform_url" ; then
         echo " failed"
         exit -1


### PR DESCRIPTION
Extract the 'header' part of the URL.  Remove the word 'latest' from
the download status message, since the specified URL isn't necessarily
the latest.

Fixes #36.